### PR TITLE
Remove jsx and use preact as peerDependency

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,4 +1,3 @@
 {
-    "presets": ["es2015", "react"],
-    "plugins": [ ["transform-react-jsx", { "pragma": "h" }] ]
+    "presets": ["es2015"]
 }

--- a/package.json
+++ b/package.json
@@ -18,9 +18,7 @@
     "babel-eslint": "^7.0.0",
     "babel-loader": "^6.2.4",
     "babel-preset-es2015": "^6.9.0",
-    "babel-preset-react": "^6.11.1",
-    "eslint": "^3.2.2",
-    "eslint-plugin-react": "^6.0.0"
+    "eslint": "^3.2.2"
   },
   "scripts": {
     "build": "eslint js && babel waypoint.js --out-file waypoint.build.js"

--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
   },
   "author": "dzhurley",
   "homepage": "https://github.com/dzhurley/preact-waypoint",
-  "dependencies": {
-    "preact": "^6.3.0"
+  "peerDependencies": {
+    "preact": ">= 6.3.0"
   },
   "devDependencies": {
     "babel-cli": "^6.16.0",

--- a/waypoint.js
+++ b/waypoint.js
@@ -2,7 +2,7 @@ const { h, Component } = require('preact');
 
 class Waypoint extends Component {
     isInside() {
-        const waypointTop = this.mark.getBoundingClientRect().top;
+        const waypointTop = this.base.getBoundingClientRect().top;
 
         const contextHeight = this.container !== window ?
             this.container.offsetHeight :
@@ -45,8 +45,7 @@ class Waypoint extends Component {
     }
 
     render() {
-        // use mark later to check scroll position against
-        return <span ref={e => this.mark = e} />;
+        return h('span');
     }
 }
 


### PR DESCRIPTION
Thanks for this port, is really cool!

This pr contains the following changes:

- `preact` is now a peerDependency so you don't end up loading 2 versions of `preact` for your project
- Since the only component you build is a span you can just use the hyperscript syntax and save the time and dependencies on transpiling jsx
- Because you are only referring to the top dom element (the span) we can use `preact` `this.base` instead